### PR TITLE
Use leibniz equality

### DIFF
--- a/src/Type/Equality.purs
+++ b/src/Type/Equality.purs
@@ -2,6 +2,7 @@ module Type.Equality
   ( class TypeEquals
   , to
   , from
+  , leibniz
   ) where
 
 -- | This type class asserts that types `a` and `b`
@@ -14,10 +15,21 @@ module Type.Equality
 -- | Note: any instance will necessarily overlap with
 -- | `refl` below, so instances of this class should
 -- | not be defined in libraries.
+-- class TypeEquals :: forall k. k -> k -> Constraint
 class TypeEquals a b | a -> b, b -> a where
-  to :: a -> b
-  from :: b -> a
+  leibniz :: forall p. p a -> p b
 
 instance refl :: TypeEquals a a where
-  to a = a
-  from a = a
+  leibniz a = a
+
+newtype To a = To a
+
+to :: forall a b. TypeEquals a b => a -> b
+to a = case leibniz (To a) of
+  To b -> b
+
+newtype From a b = From (b -> a)
+
+from :: forall a b. TypeEquals a b => b -> a
+from b = case leibniz (From (\a -> a) :: From a a) of
+  (From f :: From a b) -> f b

--- a/src/Type/Equality.purs
+++ b/src/Type/Equality.purs
@@ -3,6 +3,7 @@ module Type.Equality
   , to
   , from
   , leibniz
+  , leibnizOp
   ) where
 
 -- | This type class asserts that types `a` and `b`
@@ -15,12 +16,19 @@ module Type.Equality
 -- | Note: any instance will necessarily overlap with
 -- | `refl` below, so instances of this class should
 -- | not be defined in libraries.
--- class TypeEquals :: forall k. k -> k -> Constraint
+class TypeEquals :: forall k. k -> k -> Constraint
 class TypeEquals a b | a -> b, b -> a where
   leibniz :: forall p. p a -> p b
 
 instance refl :: TypeEquals a a where
   leibniz a = a
+
+newtype Op :: forall k. k -> k -> Type
+newtype Op a b = Op (forall p. p b -> p a)
+
+leibnizOp :: forall p a b. TypeEquals a b => p b -> p a
+leibnizOp = case leibniz (Op (\pa -> pa) :: Op a a) of
+  (Op f :: Op a b) -> f
 
 newtype To a = To a
 
@@ -28,8 +36,6 @@ to :: forall a b. TypeEquals a b => a -> b
 to a = case leibniz (To a) of
   To b -> b
 
-newtype From a b = From (b -> a)
-
 from :: forall a b. TypeEquals a b => b -> a
-from b = case leibniz (From (\a -> a) :: From a a) of
-  (From f :: From a b) -> f b
+from b = case leibnizOp (To b) of
+  To a -> a

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,7 +4,7 @@ import Prelude
 import Effect (Effect)
 import Effect.Console (log)
 import Data.Newtype (class Newtype, unwrap)
-import Type.Equality (class TypeEquals, to, from)
+import Type.Equality (class TypeEquals, leibniz, to, from)
 
 newtype RecordNewtype = RecordNewtype
   { message :: String }
@@ -15,5 +15,8 @@ instance newtypeRecordNewtype ::
   wrap = RecordNewtype <<< to
   unwrap (RecordNewtype rec) = from rec
 
+test2 :: forall ty row. TypeEquals row ( message :: String ) => Newtype ty (Record row) => ty -> String
+test2 = unwrap >>> leibniz >>> _.message
+
 main :: Effect Unit
-main = log (unwrap (RecordNewtype { message: "Done" })).message
+main = log (test2 (RecordNewtype { message: "Done" }))


### PR DESCRIPTION
Using Leibniz equality lets us have polykinds and also have more evidence for stronger coercions down the line (not just to/from, which need to be manually threaded through functor-y things).

This should be backwards-compatible, since we have the same public API.